### PR TITLE
Disable autoplay

### DIFF
--- a/layouts/aframes/single.html
+++ b/layouts/aframes/single.html
@@ -54,7 +54,6 @@
             <a-assets>
                 <video id="mainVideo" preload="auto"
                        src="{{ .Params.vidSrc }}"
-                       autoplay
                        width="160" height="90" loop="true"
                        crossOrigin="anonymous"></video>
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -51,7 +51,7 @@ AFRAME.registerSystem('video', {
     },
 
     state: {
-        playing: true,
+        playing: false,
         hotspotsVisible: true
     },
 


### PR DESCRIPTION
Playing the 360 video causes the cpu fan turn on. Let's disable this by
default, so opening new tabs doesn't cause things to go crazy.