### PR TITLE
Fix hotspot icon

### DIFF
--- a/layouts/aframes/single.html
+++ b/layouts/aframes/single.html
@@ -130,7 +130,7 @@
 
                 <a-entity class="menu-button" mixin="frame">
                     <a-entity
-                        material="src: #hotspot-icon;"
+                        material="src: #hotspot-icon; transparent: true;"
                         mixin="poster">
                     </a-entity>
                 </a-entity>


### PR DESCRIPTION
Just add "transparent: true" to the material. This was way easier than I
expected.